### PR TITLE
Feature/fetch tables

### DIFF
--- a/cypress/e2e/tables-api.cy.js
+++ b/cypress/e2e/tables-api.cy.js
@@ -1,0 +1,27 @@
+describe('API Tables', () => {
+  const apiUrl = 'http://localhost:3001/tables'; // adapte si besoin
+
+  it('GET /tables - doit retourner la liste des tables', () => {
+    cy.request('GET', apiUrl).then((response) => {
+      expect(response.status).to.eq(200);
+      expect(response.body).to.be.an('array');
+      // Optionnel : vérifier la structure d'une table
+      if (response.body.length > 0) {
+        expect(response.body[0]).to.have.property('id');
+        expect(response.body[0]).to.have.property('name');
+      }
+    });
+  });
+
+  it('GET /tables/:id - doit retourner une table précise', () => {
+    cy.request('GET', apiUrl).then((response) => {
+      const firstTable = response.body[0];
+      cy.request('GET', `${apiUrl}/${firstTable.id}`).then((res) => {
+        expect(res.status).to.eq(200);
+        expect(res.body).to.have.property('id', firstTable.id);
+      });
+    });
+  });
+
+  // Ajoute d'autres tests POST, etc. selon tes besoins
+}); 

--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import PrivateRoute from './auth/components/PrivateRoute';
 import Navbar from './auth/components/Navbar';
 import Home from './Home'; // Créer ce composant plus tard
 import LandingPage from './components/LandingPage';
+import TablesPage from './components/TablesPage';
 
 // Import pixel art components
 import { PixelContainer } from './components/ui';
@@ -52,6 +53,14 @@ function App() {
                 <Navbar />
                 <PixelContainer className="content max-w-5xl mx-auto mt-8">
                   <Register />
+                </PixelContainer>
+              </>
+            } />
+            <Route path="/tables" element={
+              <>
+                <Navbar />
+                <PixelContainer className="content max-w-5xl mx-auto mt-8">
+                  <TablesPage />
                 </PixelContainer>
               </>
             } />

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ import PrivateRoute from './auth/components/PrivateRoute';
 import Navbar from './auth/components/Navbar';
 import Home from './Home'; // Créer ce composant plus tard
 import LandingPage from './components/LandingPage';
-import TablesPage from './components/TablesPage';
+import TablesPage, { TableView } from './components/TablesPage';
 
 // Import pixel art components
 import { PixelContainer } from './components/ui';
@@ -61,6 +61,14 @@ function App() {
                 <Navbar />
                 <PixelContainer className="content max-w-5xl mx-auto mt-8">
                   <TablesPage />
+                </PixelContainer>
+              </>
+            } />
+            <Route path="/tables/:id" element={
+              <>
+                <Navbar />
+                <PixelContainer className="content max-w-5xl mx-auto mt-8">
+                  <TableView />
                 </PixelContainer>
               </>
             } />

--- a/src/__tests__/TablesPage.test.jsx
+++ b/src/__tests__/TablesPage.test.jsx
@@ -56,6 +56,7 @@ function renderWithRouter(ui) {
 
 describe('TablesPage', () => {
   beforeEach(() => {
+    (useAuth).mockReturnValue({ isAuthenticated: false });
     jest.clearAllMocks();
   });
 

--- a/src/__tests__/TablesPage.test.jsx
+++ b/src/__tests__/TablesPage.test.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+// À adapter selon l'emplacement réel du composant TablesPage
+import TablesPage from '../components/TablesPage';
+import { BrowserRouter } from 'react-router-dom';
+
+// Mocks à adapter selon ton implémentation réelle
+jest.mock('../api/tables');
+jest.mock('../auth/context/AuthContext');
+
+import { fetchTables, joinTable } from '../api/tables';
+import { useAuth } from '../auth/context/AuthContext';
+
+const mockTables = [
+  {
+    id: 1,
+    name: 'Beginner Table',
+    status: 'Waiting',
+    round: 1,
+    turn: 1,
+    currentBlind: 25,
+    smallBlind: 10,
+    bigBlind: 25,
+    currentBet: 0,
+    pot: 0,
+    dealerPosition: 0,
+    river: [],
+    players: [],
+    maxPlayers: 4,
+    minPlayers: 2,
+    gameLog: []
+  },
+  {
+    id: 2,
+    name: 'Intermediate Table',
+    status: 'Waiting',
+    round: 1,
+    turn: 1,
+    currentBlind: 50,
+    smallBlind: 25,
+    bigBlind: 50,
+    currentBet: 0,
+    pot: 0,
+    dealerPosition: 0,
+    river: [],
+    players: [],
+    maxPlayers: 4,
+    minPlayers: 2,
+    gameLog: []
+  },
+];
+
+function renderWithRouter(ui) {
+  return render(<BrowserRouter>{ui}</BrowserRouter>);
+}
+
+describe('TablesPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('affiche un état de chargement pendant le fetch', async () => {
+    (fetchTables).mockReturnValue(new Promise(() => {}));
+    renderWithRouter(<TablesPage />);
+    expect(screen.getByText(/chargement/i)).toBeInTheDocument();
+  });
+
+  it('affiche la liste des tables après un fetch réussi', async () => {
+    (fetchTables).mockResolvedValue(mockTables);
+    renderWithRouter(<TablesPage />);
+    expect(await screen.findByText('Beginner Table')).toBeInTheDocument();
+    expect(screen.getByText('Intermediate Table')).toBeInTheDocument();
+  });
+
+  it('affiche un message d\'erreur si le fetch échoue', async () => {
+    (fetchTables).mockRejectedValue(new Error('Erreur réseau'));
+    renderWithRouter(<TablesPage />);
+    expect(await screen.findByText(/erreur/i)).toBeInTheDocument();
+  });
+
+  it('affiche un bouton "Rejoindre" pour chaque table', async () => {
+    (fetchTables).mockResolvedValue(mockTables);
+    renderWithRouter(<TablesPage />);
+    expect(await screen.findAllByRole('button', { name: /rejoindre/i })).toHaveLength(2);
+  });
+
+  it('redirige vers l\'inscription si non authentifié au clic sur "Rejoindre"', async () => {
+    (fetchTables).mockResolvedValue(mockTables);
+    (useAuth).mockReturnValue({ isAuthenticated: false });
+    renderWithRouter(<TablesPage />);
+    const joinButtons = await screen.findAllByRole('button', { name: /rejoindre/i });
+    fireEvent.click(joinButtons[0]);
+    await waitFor(() => {
+      // À adapter selon ta logique de redirection
+      expect(window.location.pathname).toBe('/signup');
+    });
+  });
+
+  it("appelle l'API joinTable si authentifié au clic sur 'Rejoindre'", async () => {
+    (fetchTables).mockResolvedValue(mockTables);
+    (useAuth).mockReturnValue({ isAuthenticated: true, user: { id: 42 } });
+    (joinTable).mockResolvedValue({ success: true, table: mockTables[0] });
+    renderWithRouter(<TablesPage />);
+    const joinButtons = await screen.findAllByRole('button', { name: /rejoindre/i });
+    fireEvent.click(joinButtons[0]);
+    await waitFor(() => {
+      expect(joinTable).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/src/api/tables.js
+++ b/src/api/tables.js
@@ -1,8 +1,12 @@
+import api from './axiosConfig';
+
 // Fonctions factices pour être mockées dans les tests
 export const fetchTables = async () => {
-  return [];
+  const response = await api.get('/tables');
+  return response.data;
 };
 
 export const joinTable = async (tableId) => {
-  return { success: true };
+  const response = await api.post(`/tables/${tableId}`, { action: 'join' });
+  return response.data;
 }; 

--- a/src/api/tables.js
+++ b/src/api/tables.js
@@ -1,0 +1,8 @@
+// Fonctions factices pour être mockées dans les tests
+export const fetchTables = async () => {
+  return [];
+};
+
+export const joinTable = async (tableId) => {
+  return { success: true };
+}; 

--- a/src/api/tables.js
+++ b/src/api/tables.js
@@ -9,4 +9,9 @@ export const fetchTables = async () => {
 export const joinTable = async (tableId) => {
   const response = await api.post(`/tables/${tableId}`, { action: 'join' });
   return response.data;
+};
+
+export const getTable = async (tableId) => {
+  const response = await api.get(`/tables/${tableId}`);
+  return response.data;
 }; 

--- a/src/auth/components/Navbar.jsx
+++ b/src/auth/components/Navbar.jsx
@@ -25,11 +25,9 @@ const Navbar = () => {
         <div className="flex flex-col sm:flex-row w-full sm:w-auto items-center gap-4">
           <div className="navbar-start flex gap-4">
             <Link to="/" className="px-2 text-white hover:text-poker-gold">Accueil</Link>
+            <Link to="/tables" className="px-2 text-white hover:text-poker-gold">Tables</Link>
             {isAuthenticated && (
-              <>
-                <Link to="/tables" className="px-2 text-white hover:text-poker-gold">Tables</Link>
-                <Link to="/profile" className="px-2 text-white hover:text-poker-gold">Profil</Link>
-              </>
+              <Link to="/profile" className="px-2 text-white hover:text-poker-gold">Profil</Link>
             )}
           </div>
           

--- a/src/auth/context/AuthContext.jsx
+++ b/src/auth/context/AuthContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useEffect, useMemo } from 'react';
+import React, { createContext, useState, useEffect, useMemo, useContext } from 'react';
 import authService from '../services/authService';
 
 // Création du contexte d'authentification
@@ -122,4 +122,7 @@ export const AuthProvider = ({ children }) => {
   );
 };
 
-export default AuthProvider; 
+export default AuthProvider;
+
+// Ajout du hook useAuth pour accès et mock facile dans les tests
+export const useAuth = () => useContext(AuthContext); 

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -72,6 +72,9 @@ const LandingPage = () => {
               <a href="#join" className="hover:text-poker-gold transition-colors">
                 JOIN
               </a>
+              <Link to="/tables" className="hover:text-poker-gold transition-colors">
+                TABLES
+              </Link>
             </div>
 
             <div className="hidden md:flex space-x-4">
@@ -118,6 +121,9 @@ const LandingPage = () => {
               <a href="#join" className="py-2" onClick={() => setMobileMenuOpen(false)}>
                 JOIN
               </a>
+              <Link to="/tables" className="py-2" onClick={() => setMobileMenuOpen(false)}>
+                TABLES
+              </Link>
               <div className="flex flex-col space-y-2 pt-2 border-t-4 border-black pixel-borders">
                 {isAuthenticated ? (
                   <>

--- a/src/components/TablesPage.jsx
+++ b/src/components/TablesPage.jsx
@@ -42,15 +42,15 @@ const TablesPage = () => {
 
   return (
     <div className="p-4 max-w-2xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Tables disponibles</h1>
+      <h1 className="text-2xl font-bold mb-4 text-white">Tables disponibles</h1>
       <ul className="space-y-4">
         {tables.map((table) => (
           <li key={table.id} className="border rounded p-4 flex flex-col md:flex-row md:items-center md:justify-between">
             <div>
-              <div className="font-semibold text-lg">{table.name}</div>
-              <div className="text-sm text-gray-600">Joueurs : {table.players.length} / {table.maxPlayers}</div>
-              <div className="text-sm text-gray-600">Blindes : {table.smallBlind} / {table.bigBlind}</div>
-              <div className="text-sm text-gray-600">Statut : {table.status}</div>
+              <div className="font-semibold text-lg text-white">{table.name}</div>
+              <div className="text-sm text-white">Joueurs : {table.players.length} / {table.maxPlayers}</div>
+              <div className="text-sm text-white">Blindes : {table.smallBlind} / {table.bigBlind}</div>
+              <div className="text-sm text-white">Statut : {table.status}</div>
             </div>
             <button
               className="mt-2 md:mt-0 bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"

--- a/src/components/TablesPage.jsx
+++ b/src/components/TablesPage.jsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react';
+import { fetchTables, joinTable } from '../api/tables';
+import { useAuth } from '../auth/context/AuthContext';
+import { useNavigate } from 'react-router-dom';
+
+const TablesPage = () => {
+  const [tables, setTables] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const { isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    fetchTables()
+      .then((data) => {
+        setTables(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err.message || 'Erreur lors du chargement des tables');
+        setLoading(false);
+      });
+  }, []);
+
+  const handleJoin = async (tableId) => {
+    if (!isAuthenticated) {
+      navigate('/signup');
+      return;
+    }
+    try {
+      await joinTable(tableId);
+      // Redirection ou feedback à ajouter ici si besoin
+    } catch (err) {
+      setError(err.message || "Erreur lors de la tentative de rejoindre la table");
+    }
+  };
+
+  if (loading) return <div>Chargement...</div>;
+  if (error) return <div>Erreur : {error}</div>;
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Tables disponibles</h1>
+      <ul className="space-y-4">
+        {tables.map((table) => (
+          <li key={table.id} className="border rounded p-4 flex flex-col md:flex-row md:items-center md:justify-between">
+            <div>
+              <div className="font-semibold text-lg">{table.name}</div>
+              <div className="text-sm text-gray-600">Joueurs : {table.players.length} / {table.maxPlayers}</div>
+              <div className="text-sm text-gray-600">Blindes : {table.smallBlind} / {table.bigBlind}</div>
+              <div className="text-sm text-gray-600">Statut : {table.status}</div>
+            </div>
+            <button
+              className="mt-2 md:mt-0 bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+              onClick={() => handleJoin(table.id)}
+            >
+              Rejoindre
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default TablesPage; 


### PR DESCRIPTION
## ✨ Merge: `feature/fetch-tables` – Vue Tables, Navigation, API & Tests

### 📋 Fonctionnalités principales

- Affichage de la **liste des tables** avec récupération dynamique depuis l’API backend
- Possibilité de **rejoindre une table** (`POST /tables/:id`) avec gestion de l’**état d’authentification**
- **Redirection automatique** vers la page de la table après un join (ou si déjà membre)
- Page individuelle `/tables/:id` affichant :
  - Joueurs
  - Blindes
  - Pot
  - Autres infos de table

---

### 🧭 Navigation & UI

- Lien “**Tables**” accessible à tous depuis la **navbar** et la **landing page**
- Meilleure lisibilité : textes en **blanc**, **feedback utilisateur** visuel
- Gestion des **erreurs** :
  - Tentative de join déjà effectuée
  - Réponses d’erreur de l’API

---

### 🔌 API & intégration

- Connexion réelle du frontend à l’API backend :
  - `fetchTables`
  - `joinTable`
  - `getTable`
- Ajout de **tests Cypress** pour valider les routes :
  - `/tables`
  - `/tables/:id`

---

### 🧱 Refactoring & structure

- Découpage clair des composants :
  - `TablesPage`
  - `TableView`
- Ajout de la route `/tables/:id` dans le **router**
- Nettoyage des **mocks** et branchement sur l’**API réelle**

---

### 🎯 Objectif de la MR

Cette merge request **pose les bases** :
- De la **navigation multi-tables**
- De l’**intégration API réelle**
- Et de la **future logique de jeu**
